### PR TITLE
Check README version matches package.json

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -11,6 +11,31 @@ on:
       - main
 
 jobs:
+  version:
+    name: Check README version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Compare README pins against package.json
+        run: |
+          version=$(node -p "require('./package.json').version")
+          refs=$(grep -oE 'harryzcy/action-bark@[^ ]+' README.md | sed 's/.*@//' | sort -u)
+
+          if [ -z "$refs" ]; then
+            echo "::error::README.md has no harryzcy/action-bark@<version> reference"
+            exit 1
+          fi
+
+          if [ "$refs" != "v$version" ]; then
+            echo "::error::README.md pins $(echo $refs | tr '\n' ' ')but package.json is $version"
+            grep -n 'harryzcy/action-bark@' README.md
+            exit 1
+          fi
+
+          echo "README.md pins v$version, matching package.json"
+
   test:
     name: Build & Test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Allow GitHub Actions to push iOS notifications via Bark
 
 ```yaml
 steps:
-  - uses: harryzcy/action-bark@v1
+  - uses: harryzcy/action-bark@v2.4.0
     with:
         status: ${{ job.status }}
         device_key: ${{ secrets.BARK_DEVICE_KEY }}
@@ -20,7 +20,7 @@ More controls over notifications:
 
 ```yaml
 steps:
-  - uses: harryzcy/action-bark@v1
+  - uses: harryzcy/action-bark@v2.4.0
     with:
         status: ${{ job.status }}
         on_status: failure, cancelled # only run on these status
@@ -34,7 +34,7 @@ Custom title and body:
 
 ```yaml
 steps:
-  - uses: harryzcy/action-bark@v1
+  - uses: harryzcy/action-bark@v2.4.0
     with:
         status: ${{ job.status }}
         title: custom title
@@ -49,7 +49,7 @@ steps:
 
 ```yaml
 steps:
-  - uses: harryzcy/action-bark@v1
+  - uses: harryzcy/action-bark@v2.4.0
     with:
         status: ${{ job.status }}
         device_key: ${{ secrets.BARK_DEVICE_KEY }}


### PR DESCRIPTION
README pinned `@v1`, which has never resolved — there is no `v1` tag or branch, only `v1.0.x` tags and `releases/v1`. All four examples now use `@v2.4.0`.

Adds a `version` job that fails unless every README pin matches `package.json`, so the two can't drift again. No `npm install`, runs in ~5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
