### PR TITLE
Add workflows to prepare and tag releases

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,80 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: New version, without the leading v (e.g. 2.5.0)
+        required: true
+        type: string
+
+jobs:
+  prepare:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      # RELEASE_TOKEN is a PAT with contents:write and pull-requests:write.
+      # Without it, the push and PR are attributed to GITHUB_TOKEN, which does
+      # not trigger workflow runs — the required "Build & Test" check would
+      # never report and the PR could not be merged.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Validate version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Version must be X.Y.Z without a leading v, got '$VERSION'"
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            echo "::error::Tag v$VERSION already exists"
+            exit 1
+          fi
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: latest
+
+      - name: Install
+        run: npm ci
+
+      - name: Bump version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          npm version "$VERSION" --no-git-tag-version
+          sed -i -E "s|harryzcy/action-bark@v[0-9]+\.[0-9]+\.[0-9]+|harryzcy/action-bark@v$VERSION|g" README.md
+
+      - name: Build
+        run: npm run all
+
+      - name: Open release pull request
+        env:
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git switch -c "release/v$VERSION"
+          git add package.json package-lock.json README.md dist
+          git commit -m "Prepare v$VERSION release"
+          git push origin "release/v$VERSION"
+
+          gh pr create \
+            --base main \
+            --head "release/v$VERSION" \
+            --title "Prepare v$VERSION release" \
+            --body "Bumps to v$VERSION and rebuilds \`dist/\` from the current lockfile.
+
+          Merging tags v$VERSION and cuts the GitHub Release."

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,42 @@
+name: Tag Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  tag:
+    name: Tag Release
+    if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # Pushing the tag with RELEASE_TOKEN is what triggers release.yml.
+      # A tag pushed with GITHUB_TOKEN would not start another workflow run,
+      # and the GitHub Release would have to be created by hand.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Push tag
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          version="${HEAD_REF#release/}"
+          expected="v$(node -p "require('./package.json').version")"
+
+          if [ "$version" != "$expected" ]; then
+            echo "::error::Branch $HEAD_REF does not match package.json ($expected)"
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag "$version"
+          git push origin "$version"


### PR DESCRIPTION
Releasing means bumping `package.json`, rebuilding `dist/`, committing, and pushing a tag by hand, so nothing guarantees a tagged bundle was built from its own lockfile.

`prepare_release.yml` takes a version via dispatch and opens a `release/vX.Y.Z` PR with the bump, README pins, and a rebuilt `dist/`. `tag_release.yml` tags the merge commit, which triggers the existing `release.yml`.

Needs a `RELEASE_TOKEN` PAT with contents and pull-requests write. Both workflows fall back to `GITHUB_TOKEN`, which cannot trigger the required checks or the release.